### PR TITLE
Guarding emdb.h against possible conflicts with stdlib.h

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Rubén Santos <ribal@cocaine.ninja>
+Copyright (c) 2019 Eugenio M. Vigo <emvigo@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/emdb.c
+++ b/emdb.c
@@ -1,4 +1,9 @@
 /* See LICENSE file for copyright and license details. */
+
+#define EMDB_SOURCE
+
+#include "emdb.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/emdb.h
+++ b/emdb.h
@@ -1,11 +1,23 @@
 /* See LICENSE file for copyright and license details. */
-void emdb_mem_file(size_t size, const char *file, int line);
+
+#ifndef EMDB_H
+#define EMDB_H
+
+/* This prevents conflicts whether stdlib.h is included again after or before
+ * emdb.h. Ugly hack, I know. */
+#include <stdlib.h>
+
+void emdb_mem_file(void *ptr, size_t size, const char *file, int line);
 void *emdb_malloc(size_t size, const char *file, int line);
 void *emdb_calloc(size_t count, size_t size, const char *file, int line);
 void *emdb_realloc(void *ptr, size_t size, const char *file, int line);
 void emdb_free(void *ptr, const char *file, int line);
 
+#ifndef EMDB_SOURCE
 #define malloc(s) emdb_malloc(s, __FILE__, __LINE__)
 #define calloc(c, s) emdb_calloc(c, s, __FILE__, __LINE__)
 #define realloc(p, s) emdb_realloc(p, s, __FILE__, __LINE__)
 #define free(p) emdb_free(p, __FILE__, __LINE__)
+#endif
+
+#endif

--- a/test.c
+++ b/test.c
@@ -1,0 +1,19 @@
+/* See LICENSE file for copyright and license details. */
+
+/* Compile with: 
+ * gcc -o test test.c emdb.c -Wall -Wextra -Wpedantic -std=c99
+ */
+
+#include "emdb.h"
+
+/* Even though we include stdlib.h after emdb.h, the macros in emdb.h are still
+ * in force. */
+#include <stdlib.h>
+
+int main(void)
+{
+    char *test = calloc(10, sizeof(char));
+
+    /* Not free'ing so we do get a memfile!  */
+    return 0;
+}


### PR DESCRIPTION
The upstream version of emdb.h may produce conflicts with stdlib.h depending on the order of inclusion of these two header files in a user-defined source file. This PR solves that. It also allows using the header in the definition source file (emdb.c), so that declarations and definitions can be checked together by the compiler.
A trivial test case (test.c) is also included.