### PR TITLE
emdb now compiles to shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test
+libemdb.*
+*.o
 *mem

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+#See LICENSE file for copyright and license details.
+
 LIBSHORT := libemdb.so
 LIBNAME := ${LIBSHORT}.0.0.0
 LIBSONAME := ${LIBSHORT}.0
@@ -36,4 +38,4 @@ clean:
 	rm *.o
 
 purge: clean
-	rm *.so.*
+	rm libemdb.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+LIBSHORT := libemdb.so
+LIBNAME := ${LIBSHORT}.0.0.0
+LIBSONAME := ${LIBSHORT}.0
+
+LIBSRC := $(wildcard *.c)
+LIBOBJ := $(LIBSRC:%.c=%.o)
+
+PREFIX ?= /usr/local
+LIBDIR ?= ${PREFIX}/lib
+HEADDIR ?= ${PREFIX}/include
+
+CPPFLAGS := -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2
+CFLAGS := -std=c99 -pedantic -Wall -Wno-deprecated-declarations ${CPPFLAGS}
+FPIC := -fPIC
+LDFLAGS := ${FPIC} -shared -Wl,-soname,${LIBSONAME}
+
+.PHONY: clean purge install
+
+${LIBNAME}: ${LIBOBJ}
+	cc ${CFLAGS} ${LDFLAGS} $^ -o $@ -lc
+
+%.o: %.c
+	cc ${CFLAGS} ${FPIC} -c $<
+
+install:
+	install -m 644 emdb.h ${DESTDIR}${HEADDIR}/emdb.h
+
+	install -m 755 ${LIBNAME} ${DESTDIR}${LIBDIR}/${LIBNAME}
+	ln -fs ${DESTDIR}${LIBDIR}/${LIBNAME} ${DESTDIR}${LIBDIR}/${LIBSHORT}
+	ln -fs ${DESTDIR}${LIBDIR}/${LIBNAME} ${DESTDIR}${LIBDIR}/${LIBSONAME}
+	ldconfig
+
+clean:
+	rm *.o
+
+purge: clean
+	rm *.so.*

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ LDFLAGS := ${FPIC} -shared -Wl,-soname,${LIBSONAME}
 
 ${LIBNAME}: ${LIBOBJ}
 	cc ${CFLAGS} ${LDFLAGS} $^ -o $@ -lc
+	ln -fs ${LIBNAME} ${LIBSHORT}
+	ln -fs ${LIBNAME} ${LIBSONAME}
 
 %.o: %.c
 	cc ${CFLAGS} ${FPIC} -c $<

--- a/TODO
+++ b/TODO
@@ -3,5 +3,4 @@
 * breaking assert
 * hexdump structs
 * optional file logging
-* shared lib
 * hot reload

--- a/build
+++ b/build
@@ -3,4 +3,4 @@
 
 CPPFLAGS="-D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2"
 CFLAGS="-std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os $CPPFLAGS"
-cc $CFLAGS test.c emdb.c -o test
+cc $CFLAGS test.c -o test -L./ -L/usr/local/lib -lemdb

--- a/test/build
+++ b/test/build
@@ -3,4 +3,4 @@
 
 CPPFLAGS="-D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2"
 CFLAGS="-std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os $CPPFLAGS"
-cc $CFLAGS test.c -o test -L./ -L/usr/local/lib -lemdb
+cc $CFLAGS test.c -o test -L../ -I../ -L/usr/local/lib -I/usr/local/include -lemdb

--- a/test/test.c
+++ b/test/test.c
@@ -1,7 +1,7 @@
 /* See LICENSE file for copyright and license details. */
 /* Compile with: gcc -o test test.c emdb.c -Wall -Wextra -Wpedantic -std=c99 */
 
-#include "emdb.h"
+#include <emdb.h>
 
 /* even though we include stdlib.h after emdb.h, the macros in emdb.h are still in force. */
 #include <stdlib.h>


### PR DESCRIPTION
A new Makefile is provided that compiles emdb into a soname-compatible shared library. The library and header files may be installed using `make install` into /usr/local/lib and /usr/local/include, respectively (caveat: some distros may not have these paths ready for use. If that's the case, use -L and -I when compiling a program using emdb and set LD_LIBRARY_PATH accordingly before running the program).

In order to have a simpler Makefile, the test suite and its build script have been moved to test/.