### PR TITLE
Detecting stack vs. heap allocation

### DIFF
--- a/emdb.c
+++ b/emdb.c
@@ -94,7 +94,7 @@ emdb_free(void *ptr, const char *file, int line)
 	sprintf(buf, "%p.mem", ptr);
 	if (unlink(buf) < 0)
 		printf("Double free: %p File: %s Line: %d\n", ptr, file, line);
-	
+	 
 	free(ptr);
 
 	size_t i;
@@ -125,7 +125,7 @@ emdb_hexdump(char *p, int s)
 	unsigned char c[0x10];
 
 	/* table header */
-	printf (">>		 ");
+	printf (">>      ");
 	for (i = 0; i < 0x10; i++)
 		printf (" #%x",i);
 	printf (" #");
@@ -144,7 +144,7 @@ emdb_hexdump(char *p, int s)
 			printf (" %02x", p[i]);
 			c[i & 0xf] = ((p[i] < 0x20) || (p[i] > 0x7e)) ? '.' : p[i];
 		} else {
-			printf ("	");
+			printf ("   ");
 			c[i & 0xf] = ' ';
 		}
 	}

--- a/emdb.c
+++ b/emdb.c
@@ -8,6 +8,19 @@
 #include <stdio.h>
 #include <unistd.h>
 
+static size_t heap_catalog[HEAP_MAX];
+static size_t heap_last = 0;
+static size_t heap_set = 0;
+
+static void
+heap_init(void)
+{
+	if(!heap_set) {
+		memset(heap_catalog, 0, sizeof(heap_catalog));
+		heap_set = 1;
+	}
+}
+
 void
 emdb_mem_file(void *ptr, size_t size, const char *file, int line)
 {
@@ -22,11 +35,15 @@ emdb_mem_file(void *ptr, size_t size, const char *file, int line)
 void *
 emdb_malloc(size_t size, const char *file, int line)
 {
+	heap_init();
+	
 	void *p;
 
 	if (!(p = malloc(size)))
 		return NULL;
 
+	heap_catalog[heap_last] = (size_t)p;
+	++heap_last;
 	emdb_mem_file(p, size, file, line);
 
 	return p;
@@ -35,11 +52,15 @@ emdb_malloc(size_t size, const char *file, int line)
 void *
 emdb_calloc(size_t count, size_t size, const char *file, int line)
 {
+	heap_init();
+	
 	void *p;
 
 	if (!(p = calloc(count, size)))
 		return NULL;
 
+	heap_catalog[heap_last] = (size_t)p;
+	++heap_last;
 	emdb_mem_file(p, count * size, file, line);
 
 	return p;
@@ -66,13 +87,35 @@ emdb_realloc(void *ptr, size_t size, const char *file, int line)
 void
 emdb_free(void *ptr, const char *file, int line)
 {
+	heap_init();
+	
 	char buf[256];
 
 	sprintf(buf, "%p.mem", ptr);
 	if (unlink(buf) < 0)
 		printf("Double free: %p File: %s Line: %d\n", ptr, file, line);
-
+	
 	free(ptr);
+
+	size_t i;
+	for(i = 0; i < HEAP_MAX; ++i) {
+		if(heap_catalog[i] == (size_t)ptr) {
+			heap_catalog[i] = 0;
+		}
+	}
+}
+
+int
+emdb_var_is_dyn(void *ptr)
+{
+	size_t i;
+	for(i = 0; i < HEAP_MAX; ++i) {
+		if(heap_catalog[i] == (size_t)ptr) {
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
 void
@@ -82,7 +125,7 @@ emdb_hexdump(char *p, int s)
 	unsigned char c[0x10];
 
 	/* table header */
-	printf (">>      ");
+	printf (">>		 ");
 	for (i = 0; i < 0x10; i++)
 		printf (" #%x",i);
 	printf (" #");
@@ -101,7 +144,7 @@ emdb_hexdump(char *p, int s)
 			printf (" %02x", p[i]);
 			c[i & 0xf] = ((p[i] < 0x20) || (p[i] > 0x7e)) ? '.' : p[i];
 		} else {
-			printf ("   ");
+			printf ("	");
 			c[i & 0xf] = ' ';
 		}
 	}

--- a/emdb.h
+++ b/emdb.h
@@ -10,12 +10,12 @@
  * emdb.h. Ugly hack, I know. */
 #include <stdlib.h>
 
-#define EMDB_RED	 "\033[1m\033[31m"
-#define EMDB_GREEN	 "\033[1m\033[32m"
-#define EMDB_YELLOW	 "\033[1m\033[33m"
-#define EMDB_BLUE	 "\033[1m\033[34m"
-#define EMDB_PURPLE	 "\033[1m\033[34m"
-#define EMDB_RESET	 "\033[0m"
+#define EMDB_RED     "\033[1m\033[31m"
+#define EMDB_GREEN   "\033[1m\033[32m"
+#define EMDB_YELLOW  "\033[1m\033[33m"
+#define EMDB_BLUE    "\033[1m\033[34m"
+#define EMDB_PURPLE  "\033[1m\033[34m"
+#define EMDB_RESET   "\033[0m"
 
 #define HEAP_MAX 1024 // Maximum allocation calls allowed
 
@@ -35,30 +35,30 @@ void emdb_hexdump(char *p, int s);
 #endif
 
 /* dumps */
-#define DUMPINT(x, d) do {													   \
-		printf("[%s:%d] #%s\nVALUE: %d | SIZE: %lu\n",						   \
-			   __FILE__, __LINE__, #x, x, sizeof(x));						   \
-		if (d) emdb_hexdump((char *)(&x), sizeof(int));						   \
-		printf("\n");														   \
+#define DUMPINT(x, d) do {                                                     \
+        printf("[%s:%d] #%s\nVALUE: %d | SIZE: %lu\n",                         \
+               __FILE__, __LINE__, #x, x, sizeof(x));                          \
+        if (d) emdb_hexdump((char *)(&x), sizeof(int));                        \
+        printf("\n");                                                          \
 } while (0)
-#define DUMPSTR(x, d) do {													   \
-		printf("[%s:%d] #%s\nVALUE: %s | SIZE: %lu | LENGTH: %lu\n",		   \
-			   __FILE__, __LINE__, #x, x, sizeof(x), strlen(x));			   \
-		if (d) emdb_hexdump(x, strlen(x));									   \
-		printf("\n");														   \
+#define DUMPSTR(x, d) do {                                                     \
+        printf("[%s:%d] #%s\nVALUE: %s | SIZE: %lu | LENGTH: %lu\n",           \
+               __FILE__, __LINE__, #x, x, sizeof(x), strlen(x));               \
+        if (d) emdb_hexdump(x, strlen(x));                                     \
+        printf("\n");                                                          \
 } while (0)
 
 /* debug messages */
 #define emdb_debug(tag, color, msg) printf(color "[" tag ":%s:%d] " msg EMDB_RESET "\n", __FILE__, __LINE__)
-#define DEBUG(...)	 emdb_debug("INFO",	   EMDB_BLUE,	__VA_ARGS__)
-#define DEBUGW(...)	 emdb_debug("WARNING", EMDB_YELLOW, __VA_ARGS__)
-#define DEBUGE(...)	 emdb_debug("ERROR",   EMDB_RED,	__VA_ARGS__)
-#define DEBUGOK(...) emdb_debug("OK",	   EMDB_GREEN,	__VA_ARGS__)
+#define DEBUG(...)   emdb_debug("INFO",    EMDB_BLUE,   __VA_ARGS__)
+#define DEBUGW(...)  emdb_debug("WARNING", EMDB_YELLOW, __VA_ARGS__)
+#define DEBUGE(...)  emdb_debug("ERROR",   EMDB_RED,    __VA_ARGS__)
+#define DEBUGOK(...) emdb_debug("OK",      EMDB_GREEN,  __VA_ARGS__)
 
 /* time */
-#define SLEEP(t)	   do { struct timespec tv = { .tv_sec = t,				.tv_nsec = 0							  }; nanosleep(&tv, &tv); } while (0)
-#define SLEEP_MILI(t)  do { struct timespec tv = { .tv_sec = t/1000,		.tv_nsec = (t%1000)*1000000L			  }; nanosleep(&tv, &tv); } while (0)
-#define SLEEP_MICRO(t) do { struct timespec tv = { .tv_sec = t/1000000L,	.tv_nsec = (t%1000000L)*1000000000L		  }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP(t)       do { struct timespec tv = { .tv_sec = t,             .tv_nsec = 0                              }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP_MILI(t)  do { struct timespec tv = { .tv_sec = t/1000,        .tv_nsec = (t%1000)*1000000L              }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP_MICRO(t) do { struct timespec tv = { .tv_sec = t/1000000L,    .tv_nsec = (t%1000000L)*1000000000L       }; nanosleep(&tv, &tv); } while (0)
 #define SLEEP_NANO(t)  do { struct timespec tv = { .tv_sec = t/1000000000L, .tv_nsec = (t%1000000000L)*1000000000000L }; nanosleep(&tv, &tv); } while (0)
 
 #endif

--- a/emdb.h
+++ b/emdb.h
@@ -10,18 +10,21 @@
  * emdb.h. Ugly hack, I know. */
 #include <stdlib.h>
 
-#define EMDB_RED     "\033[1m\033[31m"
-#define EMDB_GREEN   "\033[1m\033[32m"
-#define EMDB_YELLOW  "\033[1m\033[33m"
-#define EMDB_BLUE    "\033[1m\033[34m"
-#define EMDB_PURPLE  "\033[1m\033[34m"
-#define EMDB_RESET   "\033[0m"
+#define EMDB_RED	 "\033[1m\033[31m"
+#define EMDB_GREEN	 "\033[1m\033[32m"
+#define EMDB_YELLOW	 "\033[1m\033[33m"
+#define EMDB_BLUE	 "\033[1m\033[34m"
+#define EMDB_PURPLE	 "\033[1m\033[34m"
+#define EMDB_RESET	 "\033[0m"
+
+#define HEAP_MAX 1024 // Maximum allocation calls allowed
 
 void emdb_mem_file(void *ptr, size_t size, const char *file, int line);
 void *emdb_malloc(size_t size, const char *file, int line);
 void *emdb_calloc(size_t count, size_t size, const char *file, int line);
 void *emdb_realloc(void *ptr, size_t size, const char *file, int line);
 void emdb_free(void *ptr, const char *file, int line);
+int emdb_var_is_dyn(void *ptr);
 void emdb_hexdump(char *p, int s);
 
 #ifndef EMDB_SOURCE
@@ -32,30 +35,30 @@ void emdb_hexdump(char *p, int s);
 #endif
 
 /* dumps */
-#define DUMPINT(x, d) do {                                                     \
-        printf("[%s:%d] #%s\nVALUE: %d | SIZE: %lu\n",                         \
-               __FILE__, __LINE__, #x, x, sizeof(x));                          \
-        if (d) emdb_hexdump((char *)(&x), sizeof(int));                        \
-        printf("\n");                                                          \
+#define DUMPINT(x, d) do {													   \
+		printf("[%s:%d] #%s\nVALUE: %d | SIZE: %lu\n",						   \
+			   __FILE__, __LINE__, #x, x, sizeof(x));						   \
+		if (d) emdb_hexdump((char *)(&x), sizeof(int));						   \
+		printf("\n");														   \
 } while (0)
-#define DUMPSTR(x, d) do {                                                     \
-        printf("[%s:%d] #%s\nVALUE: %s | SIZE: %lu | LENGTH: %lu\n",           \
-               __FILE__, __LINE__, #x, x, sizeof(x), strlen(x));               \
-        if (d) emdb_hexdump(x, strlen(x));                                     \
-        printf("\n");                                                          \
+#define DUMPSTR(x, d) do {													   \
+		printf("[%s:%d] #%s\nVALUE: %s | SIZE: %lu | LENGTH: %lu\n",		   \
+			   __FILE__, __LINE__, #x, x, sizeof(x), strlen(x));			   \
+		if (d) emdb_hexdump(x, strlen(x));									   \
+		printf("\n");														   \
 } while (0)
 
 /* debug messages */
 #define emdb_debug(tag, color, msg) printf(color "[" tag ":%s:%d] " msg EMDB_RESET "\n", __FILE__, __LINE__)
-#define DEBUG(...)   emdb_debug("INFO",    EMDB_BLUE,   __VA_ARGS__)
-#define DEBUGW(...)  emdb_debug("WARNING", EMDB_YELLOW, __VA_ARGS__)
-#define DEBUGE(...)  emdb_debug("ERROR",   EMDB_RED,    __VA_ARGS__)
-#define DEBUGOK(...) emdb_debug("OK",      EMDB_GREEN,  __VA_ARGS__)
+#define DEBUG(...)	 emdb_debug("INFO",	   EMDB_BLUE,	__VA_ARGS__)
+#define DEBUGW(...)	 emdb_debug("WARNING", EMDB_YELLOW, __VA_ARGS__)
+#define DEBUGE(...)	 emdb_debug("ERROR",   EMDB_RED,	__VA_ARGS__)
+#define DEBUGOK(...) emdb_debug("OK",	   EMDB_GREEN,	__VA_ARGS__)
 
 /* time */
-#define SLEEP(t)       do { struct timespec tv = { .tv_sec = t,             .tv_nsec = 0                              }; nanosleep(&tv, &tv); } while (0)
-#define SLEEP_MILI(t)  do { struct timespec tv = { .tv_sec = t/1000,        .tv_nsec = (t%1000)*1000000L              }; nanosleep(&tv, &tv); } while (0)
-#define SLEEP_MICRO(t) do { struct timespec tv = { .tv_sec = t/1000000L,    .tv_nsec = (t%1000000L)*1000000000L       }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP(t)	   do { struct timespec tv = { .tv_sec = t,				.tv_nsec = 0							  }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP_MILI(t)  do { struct timespec tv = { .tv_sec = t/1000,		.tv_nsec = (t%1000)*1000000L			  }; nanosleep(&tv, &tv); } while (0)
+#define SLEEP_MICRO(t) do { struct timespec tv = { .tv_sec = t/1000000L,	.tv_nsec = (t%1000000L)*1000000000L		  }; nanosleep(&tv, &tv); } while (0)
 #define SLEEP_NANO(t)  do { struct timespec tv = { .tv_sec = t/1000000000L, .tv_nsec = (t%1000000000L)*1000000000000L }; nanosleep(&tv, &tv); } while (0)
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 int main(void)
-{	 
+{
 	int test_int = 20;
 	char *test_str = "Test string!";
 	char *test = calloc(10, sizeof(char)); /* not free'ing so we do get a memfile! */

--- a/test/test.c
+++ b/test/test.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 int main(void)
-{
+{	 
 	int test_int = 20;
 	char *test_str = "Test string!";
 	char *test = calloc(10, sizeof(char)); /* not free'ing so we do get a memfile! */
@@ -17,6 +17,12 @@ int main(void)
 	DEBUGW("This is a warning message");
 	DEBUGE("This is an error message");
 	DEBUGOK("This is an OK message!");
+
+	if(emdb_var_is_dyn(test))
+		DEBUGOK("Detected dynamic variable");
+
+	if(!emdb_var_is_dyn(&test_int))
+		DEBUGOK("Detected static variable");
 
 	DEBUG("Sleeping time");
 	DEBUG("2 seconds...");


### PR DESCRIPTION
This commit implements a basic set of tools that allows for determining whether a variable was allocated in stack or heap. It works by taking advantage from the fact that emdb creates malloc, et. al. wrappers to do its job. This patch creates a global array of pointers that are registered whenever a new variable is allocated using our wrappers. The emdb_var_is_dyn looks up whether the pointer is registered at the global array: if it is, the variable is dynamically allocated; if not, it is statically allocated.